### PR TITLE
Fixes and additions

### DIFF
--- a/in2lambda/json_convert/json_convert.py
+++ b/in2lambda/json_convert/json_convert.py
@@ -29,9 +29,9 @@ def converter(
 
         # add title to the question file
         if ListQuestions[i].title != "":
-            output["title"] = ListQuestions[i].title
+            output["title"] = ListQuestions[i].title + "test"
         else:
-            output["title"] = "Question " + str(i + 1)
+            output["title"] = "Question " + str(i + 1) + "test"
 
         # add main text to the question file
         output["masterContent"] = ListQuestions[i].main_text
@@ -58,7 +58,7 @@ def converter(
         os.makedirs(output_question, exist_ok=True)
 
         # create directory to put image
-        output_image = os.path.join(output_question, "media")
+        output_image = os.path.join(output_question, "media" + "test")
         os.makedirs(output_image, exist_ok=True)
 
         # write questions into directory
@@ -73,7 +73,7 @@ def converter(
             shutil.copy(image_path, output_image)  # copies image into the directory
 
         # output zip file in destination folder
-        shutil.make_archive(output_question, "zip", output_question)
+        shutil.make_archive(output_question + "test", "zip", output_question)
 
 
 def main(questions: list[Question], output_dir: str) -> None:

--- a/in2lambda/json_convert/json_convert.py
+++ b/in2lambda/json_convert/json_convert.py
@@ -24,14 +24,24 @@ def converter(
     """
     # Create output by copying template
 
+    # create directory to put the questions
+    os.makedirs(output_dir, exist_ok=True)
+    output_question = os.path.join(output_dir, "set")
+    os.makedirs(output_question, exist_ok=True)
+
+
+    # create directory to put images - should be in set
+    output_image = os.path.join(output_question, "media")
+    os.makedirs(output_image, exist_ok=True)
+
     for i in range(len(ListQuestions)):
         output = deepcopy(template)
 
         # add title to the question file
         if ListQuestions[i].title != "":
-            output["title"] = ListQuestions[i].title + "test"
+            output["title"] = ListQuestions[i].title
         else:
-            output["title"] = "Question " + str(i + 1) + "test"
+            output["title"] = "Question " + str(i + 1)
 
         # add main text to the question file
         output["masterContent"] = ListQuestions[i].main_text
@@ -39,27 +49,19 @@ def converter(
         # add parts to the question file
         if ListQuestions[i].parts:
             output["parts"][0]["content"] = ListQuestions[i].parts[0].text
-            output["parts"][0]["workedSolution"][0]["content"] = (
+            output["parts"][0]["workedSolution"]["content"] = (
                 ListQuestions[i].parts[0].worked_solution
             )
             for j in range(1, len(ListQuestions[i].parts)):
                 output["parts"].append(deepcopy(template["parts"][0]))
                 output["parts"][j]["content"] = ListQuestions[i].parts[j].text
-                output["parts"][j]["workedSolution"][0]["content"] = (
+                output["parts"][j]["workedSolution"]["content"] = (
                     ListQuestions[i].parts[j].worked_solution
                 )
 
         # Output file
-        filename = "question_" + str(i + 1) + "test"
+        filename = "question_" + str(i + 1)
 
-        # create directory to put the questions
-        os.makedirs(output_dir, exist_ok=True)
-        output_question = os.path.join(output_dir, filename)
-        os.makedirs(output_question, exist_ok=True)
-
-        # create directory to put image
-        output_image = os.path.join(output_question, "media" + "test")
-        os.makedirs(output_image, exist_ok=True)
 
         # write questions into directory
         with open(f"{output_question}/{filename}.json", "w") as file:
@@ -73,7 +75,7 @@ def converter(
             shutil.copy(image_path, output_image)  # copies image into the directory
 
         # output zip file in destination folder
-        shutil.make_archive(output_question + "test", "zip", output_question)
+        shutil.make_archive(output_question, "zip", output_question)
 
 
 def main(questions: list[Question], output_dir: str) -> None:

--- a/in2lambda/json_convert/json_convert.py
+++ b/in2lambda/json_convert/json_convert.py
@@ -50,7 +50,7 @@ def converter(
                 )
 
         # Output file
-        filename = "question_" + str(i + 1)
+        filename = "question_" + str(i + 1) + "test"
 
         # create directory to put the questions
         os.makedirs(output_dir, exist_ok=True)

--- a/in2lambda/json_convert/minimal_template.json
+++ b/in2lambda/json_convert/minimal_template.json
@@ -22,5 +22,5 @@
     "displayStructuredTutorial": true,
     "displayWorkedSolution": true
   },
-  "title": "Question title here test"
+  "title": "Question title here"
 }

--- a/in2lambda/json_convert/minimal_template.json
+++ b/in2lambda/json_convert/minimal_template.json
@@ -1,5 +1,10 @@
 {
+  "title": "Question title here",
   "masterContent": "Top level question here",
+  "publish": false,
+  "displayFinalAnswer": true,
+  "displayStructuredTutorial": true,
+  "displayWorkedSolution": true,
   "parts": [
     {
       "answer": "",
@@ -7,18 +12,11 @@
       "responseAreas": [],
       "tutorial": [],
       "universalPartId": "N/A",
-      "workedSolution": [
-        {
+      "workedSolution": {
           "content": "Part worked solution here",
           "id": "N/A",
           "title": ""
-        }
-      ]
+      }
     }
-  ],
-  "publish": false,
-  "displayFinalAnswer": true,
-  "displayStructuredTutorial": true,
-  "displayWorkedSolution": true,
-  "title": "Question title here"
+  ]
 }

--- a/in2lambda/json_convert/minimal_template.json
+++ b/in2lambda/json_convert/minimal_template.json
@@ -22,5 +22,5 @@
     "displayStructuredTutorial": true,
     "displayWorkedSolution": true
   },
-  "title": "Question title here"
+  "title": "Question title here test"
 }

--- a/in2lambda/json_convert/minimal_template.json
+++ b/in2lambda/json_convert/minimal_template.json
@@ -4,7 +4,7 @@
     {
       "answer": "",
       "content": "Part text here",
-      "responseArea": [],
+      "responseAreas": [],
       "tutorial": [],
       "universalPartId": "N/A",
       "workedSolution": [
@@ -17,10 +17,8 @@
     }
   ],
   "publish": false,
-  "questionSettings": {
-    "displayFinalAnswer": true,
-    "displayStructuredTutorial": true,
-    "displayWorkedSolution": true
-  },
+  "displayFinalAnswer": true,
+  "displayStructuredTutorial": true,
+  "displayWorkedSolution": true,
   "title": "Question title here"
 }

--- a/in2lambda/main.py
+++ b/in2lambda/main.py
@@ -1,8 +1,8 @@
 """The main input for in2lambda, defining both the CLT and main library function."""
 
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# import sys
+# import os
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
  
 
 import importlib

--- a/in2lambda/main.py
+++ b/in2lambda/main.py
@@ -1,5 +1,7 @@
 """The main input for in2lambda, defining both the CLT and main library function."""
 
+#This commented block makes it run the local files rather than the pip library (I think, I don't understand it. Kevin wrote it.)
+#
 # import sys
 # import os
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -17,7 +19,7 @@ from in2lambda.api.module import Module
 
 import subprocess
 
-
+#Converts .docx files to markdown
 def docx_to_md(docx_file: str) -> str:
     md_output = subprocess.check_output(['pandoc', docx_file, '-t', 'markdown'])
     return md_output.decode('utf-8')
@@ -63,7 +65,7 @@ def file_type(file: str) -> str:
         ):
             return "markdown"
         case "docx":
-            return "docx"  # Pandoc doesn't seem to support doc
+            return "docx"  # Pandoc doesn't seem to support .doc, and panflute doesn't like .docx.
     raise RuntimeError(f"Unsupported file extension: .{extension}")
 
 
@@ -103,7 +105,7 @@ def runner(
 
 
     if file_type(question_file) == 'docx':
-        # Convert .docx to md using Pandoc
+        # Convert .docx to md using Pandoc and proceed
         text = docx_to_md(question_file)
         input_format = "markdown"
     else:
@@ -195,8 +197,3 @@ def cli(
 
 if __name__ == "__main__":
     cli()
-#%%
-
-# import panflute as pf
-
-# pf.convert_text("PS/TestQ.docx", input_format="docx", standalone=True)

--- a/in2lambda/main.py
+++ b/in2lambda/main.py
@@ -15,6 +15,12 @@ import rich_click as click
 import in2lambda.filters
 from in2lambda.api.module import Module
 
+import subprocess
+
+
+def docx_to_md(docx_file: str) -> str:
+    md_output = subprocess.check_output(['pandoc', docx_file, '-t', 'markdown'])
+    return md_output.decode('utf-8')
 
 def file_type(file: str) -> str:
     """Determines which pandoc file format to use for a given file.
@@ -95,14 +101,21 @@ def runner(
     # Dynamically import the correct pandoc filter depending on the subject.
     filter_module = importlib.import_module(f"in2lambda.filters.{chosen_filter}.filter")
 
-    with open(question_file, "r", encoding="utf-8") as file:
-        text = file.read()
+
+    if file_type(question_file) == 'docx':
+        # Convert .docx to md using Pandoc
+        text = docx_to_md(question_file)
+        input_format = "markdown"
+    else:
+        with open(question_file, "r", encoding="utf-8") as file:
+            text = file.read()
+        input_format=file_type(question_file)
 
     # Parse the Pandoc AST using the relevant panflute filter.
     pf.run_filter(
         filter_module.pandoc_filter,
         doc=pf.convert_text(
-            text, input_format=file_type(question_file), standalone=True
+            text, input_format=input_format, standalone=True
         ),
         module=module,
         tex_file=question_file,
@@ -111,13 +124,18 @@ def runner(
 
     # If separate answer TeX file provided, parse that as well.
     if answer_file:
-        with open(answer_file, "r", encoding="utf-8") as file:
-            answer_text = file.read()
+        if file_type(answer_file) == 'docx':
+            answer_text = docx_to_md(answer_file)
+            answer_format = "markdown"
+        else:
+            with open(answer_file, "r", encoding="utf-8") as file:
+                answer_text = file.read()
+            answer_format = file_type(answer_file)
 
         pf.run_filter(
             filter_module.pandoc_filter,
             doc=pf.convert_text(
-                answer_text, input_format=file_type(answer_file), standalone=True
+                answer_text, input_format=answer_format, standalone=True
             ),
             module=module,
             tex_file=answer_file,
@@ -177,3 +195,8 @@ def cli(
 
 if __name__ == "__main__":
     cli()
+#%%
+
+# import panflute as pf
+
+# pf.convert_text("PS/TestQ.docx", input_format="docx", standalone=True)

--- a/in2lambda/main.py
+++ b/in2lambda/main.py
@@ -1,5 +1,10 @@
 """The main input for in2lambda, defining both the CLT and main library function."""
 
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+ 
+
 import importlib
 import pkgutil
 from typing import Optional


### PR DESCRIPTION
A few changes to make in2lambda work for the updated Lambda Feedback and also make it easier to use:
  
- The minimum template now matches that on the current version of Lambda Feedback, which in turn means worked solutions are correctly imported
- it now generates a single set.zip file that you can import into Lambda Feedback in one go, rather than having to do each question one at a time
- Added support for .docx files (though it is currently a bit of a workaround. I couldn't find an elegant solution, but may come back to it. From a user perspective it functions the same).